### PR TITLE
Account for spaces in security type

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -8,7 +8,7 @@ module.exports = {
     scan: '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport scan',
     connect: 'networksetup -setairportnetwork en0 "NETWORK_TOKEN" "PASSWORD_TOKEN"',
     parseScan: function(output) {
-      var lineRegex = /^\s+(.*)\s+([a-z0-9:]{17})\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+$/;
+      var lineRegex = /^\s+(.*)\s+([a-z0-9:]{17})\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+(.*)$/;
       return output.split('\n').map(function(line) {
         var parts = line.match(lineRegex);
         return parts && { SSID: parts[1], BSSID: parts[2], RSSI: parseInt(parts[3]), CHANNEL: parseInt(parts[4]), HT: parts[5], CC: parts[6], SECURITY: parts[7] };


### PR DESCRIPTION
In an area with a fair amount of networks I noticed this tool was not picking up all of them. In order to remedy this I had to make the regex more permissive.

Example output directly from the OSX tool:

```
                            SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
                   Stickeen 5GHz 58:1f:aa:e9:17:3f -75  149,+1  Y  US WPA2(PSK/AES/AES)
                   Stickeen 5GHz 60:33:4b:e5:68:4a -59  149,+1  Y  US WPA2(PSK/AES/AES)
      Woodlawn Coffee and Pastry 12:6f:3f:87:27:93 -78  40      Y  -- NONE
                            WLCP 10:6f:3f:87:27:93 -78  40      Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                    GoodNeighbor 20:aa:4b:73:71:12 -79  36,+1   Y  -- WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)
                            WLCP 10:6f:3f:87:27:92 -65  6       Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                            WLCP 10:6f:3f:e8:7e:74 -61  6       Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                  Stickeen Guest 60:33:4b:e5:68:49 -52  1       Y  US WPA2(PSK/AES/AES)
                       HOME-A489 cc:35:40:4d:a4:89 -85  11      Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                    GoodNeighbor 20:aa:4b:73:71:10 -60  10,-1   Y  -- WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)
```

Networks like `GoodNeighbor` were not showing up because it works for WPA and WPA2.
